### PR TITLE
panel-graphic-walker 0.6.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,11 +37,14 @@ requirements:
 test:
   imports:
     - panel_gwalker
+  source_files:
+    - tests
   commands:
     - pip check
   requires:
-    - python
     - pip
+# pytesting is available, but requires the building of dependencies that are not available.
+# we will keep simple testing for now.
 
 about:
   home: https://github.com/panel-extensions/panel-graphic-walker

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/p/panel_graphic_walker/panel_graphic_walker-{{ version }}.tar.gz
+  url: url: https://pypi.org/packages/source/p/panel_graphic_walker/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
   sha256: 0881df1300e17a63ada0c6689f57ddb3f435c84576278a0f6092ed1239dee9ad
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "panel-graphic-walker" %}
 {% set version = "0.6.4" %}
-{% set python_min = "3.10" %}
 
 package:
   name: {{ name|lower }}
@@ -11,13 +10,13 @@ source:
   sha256: 0881df1300e17a63ada0c6689f57ddb3f435c84576278a0f6092ed1239dee9ad
 
 build:
-  noarch: python
+  skip: true  # [py<310]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python
     - hatchling
     - hatch-vcs
     - panel >=1.6.1
@@ -27,9 +26,13 @@ requirements:
     - nodejs >=18
     - esbuild
   run:
-    - python >={{ python_min }}
+    - python
     - panel >=1.6.1
     - narwhals
+  run_constrained:
+    - duckdb
+    - gw-dsl-parser
+    - pygwalker >=0.4.9.11
 
 test:
   imports:
@@ -37,14 +40,21 @@ test:
   commands:
     - pip check
   requires:
-    - python {{ python_min }}
+    - python
     - pip
 
 about:
   home: https://github.com/panel-extensions/panel-graphic-walker
   summary: A project providing a Graphic Walker Pane for use with HoloViz Panel.
+  description: |
+    panel-graphic-walker is a Panel extension providing Graphic Walker
+    integration for data visualization. It allows users to create interactive
+    visual exploratory data analysis interfaces directly in Panel dashboards.
   license: MIT
+  license_family: MIT
   license_file: LICENSE.md
+  doc_url: https://github.com/panel-extensions/panel-graphic-walker
+  dev_url: https://github.com/panel-extensions/panel-graphic-walker
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,6 @@ requirements:
     - narwhals
   run_constrained:
     - duckdb
-    - gw-dsl-parser
     - pygwalker >=0.4.9.11
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - packaging
     - narwhals
     - pip
+    # nodejs/esbuild required, see https://github.com/panel-extensions/panel-graphic-walker/blob/main/DEVELOPER_GUIDE.md
     - nodejs >=18
     - esbuild
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,6 @@ requirements:
     - panel >=1.6.1
     - narwhals
   run_constrained:
-    - duckdb
     - pygwalker >=0.4.9.11
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: url: https://pypi.org/packages/source/p/panel_graphic_walker/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/p/panel_graphic_walker/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
   sha256: 0881df1300e17a63ada0c6689f57ddb3f435c84576278a0f6092ed1239dee9ad
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: url: https://pypi.org/packages/source/p/panel_graphic_walker/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
+  url: url: https://pypi.org/packages/source/p/panel_graphic_walker/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
   sha256: 0881df1300e17a63ada0c6689f57ddb3f435c84576278a0f6092ed1239dee9ad
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,7 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE.md
-  doc_url: https://github.com/panel-extensions/panel-graphic-walker
+  doc_url: https://github.com/panel-extensions/panel-graphic-walker/blob/main/README.md
   dev_url: https://github.com/panel-extensions/panel-graphic-walker
 
 extra:


### PR DESCRIPTION
## ☆ panel-graphic-walker 0.6.4 ☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-7935) 
[Upstream](https://github.com/panel-extensions/panel-graphic-walker)

### Changes
* Updated version and `sha`
* Updated `about` section
* Added `run_constrained` deps
* Re-organized deps based on purpose/type