### PR TITLE
Update to 0.6.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "panel-graphic-walker" %}
-{% set version = "0.6.4" %}
+{% set version = "0.6.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/p/panel_graphic_walker/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: 0881df1300e17a63ada0c6689f57ddb3f435c84576278a0f6092ed1239dee9ad
+  sha256: ae89a4a22f2db53b0bc48a2c86b95813277e3209b73b39edd306a0c8d2dc9cb7
 
 build:
   skip: true  # [py<310]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,5 +59,7 @@ about:
   dev_url: https://github.com/panel-extensions/panel-graphic-walker
 
 extra:
+  skip-lints:
+    - host_section_needs_exact_pinnings
   recipe-maintainers:
     - philippjfr


### PR DESCRIPTION
panel-graphic-walker 0.6.5

**Destination channel:** defaults

### Links

- ~~[ticket_number]()~~
- [Upstream repository](https://github.com/panel-extensions/panel-graphic-walker/)
- [Upstream changelog/diff](https://github.com/panel-extensions/panel-graphic-walker/compare/v0.6.4...v0.6.5)

### Explanation of changes:

- No dependency change between the last version on defaults (0.6.4) and this one (0.6.5).
